### PR TITLE
MessageBodyReader Provider for HAL media types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,9 +105,33 @@
             <version>[4.0.0,5.0.0)</version>
         </dependency>
         <dependency>
+            <groupId>com.theoryinpractise</groupId>
+            <artifactId>halbuilder-standard</artifactId>
+            <version>[4.0.0,5.0.0)</version>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <version>2.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-core</artifactId>
+            <version>2.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-inmemory</artifactId>
+            <version>2.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/theoryinpractise/halbuilder/jaxrs/HalBuilderMediaTypes.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/jaxrs/HalBuilderMediaTypes.java
@@ -1,0 +1,20 @@
+package com.theoryinpractise.halbuilder.jaxrs;
+
+import javax.ws.rs.core.MediaType;
+import com.theoryinpractise.halbuilder.api.RepresentationFactory;
+
+/**
+ * Helper class for MediaType handling common to {@link JaxRsHalBuilderReaderSupport}
+ * and {@link JaxRsHalBuilderSupport}.
+ */
+class HalBuilderMediaTypes {
+    private static final MediaType HAL_JSON_TYPE = MediaType.valueOf(RepresentationFactory.HAL_JSON);
+    private static final MediaType HAL_XML_TYPE = MediaType.valueOf(RepresentationFactory.HAL_XML);
+
+    /**
+     * Is the given media type supported by HalBuilder?
+     */
+    static boolean isSupported(MediaType mediaType) {
+        return mediaType.isCompatible(HAL_JSON_TYPE) || mediaType.isCompatible(HAL_XML_TYPE);
+    }
+}

--- a/src/main/java/com/theoryinpractise/halbuilder/jaxrs/JaxRsHalBuilderReaderSupport.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/jaxrs/JaxRsHalBuilderReaderSupport.java
@@ -1,0 +1,34 @@
+package com.theoryinpractise.halbuilder.jaxrs;
+
+import com.theoryinpractise.halbuilder.api.ContentRepresentation;
+import com.theoryinpractise.halbuilder.api.RepresentationFactory;
+import com.theoryinpractise.halbuilder.standard.StandardRepresentationFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Consumes({RepresentationFactory.HAL_JSON, RepresentationFactory.HAL_XML})
+public class JaxRsHalBuilderReaderSupport implements MessageBodyReader<ContentRepresentation> {
+
+    private final RepresentationFactory factory = new StandardRepresentationFactory();
+
+    @Override
+    public boolean isReadable(Class aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return ContentRepresentation.class.isAssignableFrom(aClass) && HalBuilderMediaTypes.isSupported(mediaType);
+    }
+
+    @Override
+    public ContentRepresentation readFrom(Class aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap multivaluedMap, InputStream inputStream) throws IOException {
+	return factory.readRepresentation(mediaType.toString(), new InputStreamReader(inputStream, "UTF-8"));
+    }
+
+}

--- a/src/test/java/com/theoryinpractise/halbuilder/jaxrs/JaxRsHalBuilderRoundtripTest.java
+++ b/src/test/java/com/theoryinpractise/halbuilder/jaxrs/JaxRsHalBuilderRoundtripTest.java
@@ -1,0 +1,139 @@
+package com.theoryinpractise.halbuilder.jaxrs;
+
+import java.net.URI;
+import java.util.Arrays;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.theoryinpractise.halbuilder.api.ContentRepresentation;
+import com.theoryinpractise.halbuilder.api.ReadableRepresentation;
+import com.theoryinpractise.halbuilder.api.Representation;
+import com.theoryinpractise.halbuilder.api.RepresentationFactory;
+import com.theoryinpractise.halbuilder.standard.StandardRepresentationFactory;
+
+@RunWith(Parameterized.class)
+public class JaxRsHalBuilderRoundtripTest extends JerseyTest {
+
+    private static final URI BASE = URI.create("http://example.org/");
+    private static final URI EXTRA = URI.create("http://example.org/extra");
+    private static final String EXTRA_REL = "extra";
+    private static final String PROP_KEY = "prop";
+    private static final String PROP_VALUE = "some value";
+    private static final String EMB_PROP_KEY = "other-prop";
+    private static final String EMB_PROP_VALUE = "some other value";
+
+    @Parameterized.Parameter(0)
+    public String subPath;
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> pathsToTest() {
+        return Arrays.asList(new Object[] {"json"}, new Object[] {"xml"});
+    }
+
+    @Path("test")
+    public static class TestResource {
+        private static RepresentationFactory factory = new StandardRepresentationFactory();
+
+        @Path("json")
+        @Produces(RepresentationFactory.HAL_JSON)
+        @GET
+        public Representation writeJSON() {
+            return createTestRepresentation();
+        }
+
+        @Path("xml")
+        @Produces(RepresentationFactory.HAL_XML)
+        @GET
+        public Representation writeXML() {
+            return createTestRepresentation();
+        }
+
+        private static Representation createTestRepresentation() {
+            return factory.newRepresentation(BASE)
+                .withLink(EXTRA_REL, EXTRA)
+                .withProperty(PROP_KEY, PROP_VALUE)
+                .withRepresentation(EXTRA_REL,
+                                    factory.newRepresentation(EXTRA)
+                                    .withProperty(EMB_PROP_KEY, EMB_PROP_VALUE));
+        }
+    }
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(TestResource.class)
+            .packages("com.theoryinpractise.halbuilder.jaxrs");
+    }
+
+    @Override
+    protected void configureClient(ClientConfig config) {
+        config.register(JaxRsHalBuilderReaderSupport.class);
+    }
+
+    @Test
+    public void shouldHaveProperSelfLink() {
+        Assert.assertEquals(BASE.toString(),
+                            readRepresentation().getResourceLink().getHref());
+    }
+
+    @Test
+    public void shouldHaveProperExtraLink() {
+        Assert.assertEquals(EXTRA.toString(),
+                            readRepresentation().getLinkByRel(EXTRA_REL).getHref());
+    }
+
+    @Test
+    public void shouldHaveProperPropertyValue() {
+        Assert.assertEquals(PROP_VALUE,
+                            readRepresentation().getValue(PROP_KEY));
+    }
+
+    @Test
+    public void shouldHaveOneEmbeddedResource() {
+        Assert.assertEquals(1,
+                            readRepresentation().getResources().size());
+    }
+
+    @Test
+    public void embeddedShouldHaveProperSelfLink() {
+        Assert.assertEquals(EXTRA.toString(),
+                            readEmbeddedRepresentation().getResourceLink().getHref());
+    }
+
+    @Test
+    public void embeddedShouldHaveProperPropertyValue() {
+        Assert.assertEquals(EMB_PROP_VALUE,
+                            readEmbeddedRepresentation().getValue(EMB_PROP_KEY));
+    }
+
+    @Test
+    public void shouldBeReturning200Code() {
+        Response response = target("/test/" + subPath).request().get();
+        Assert.assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void shouldBeUsingProperContentType() {
+        Response response = target("/test/" + subPath).request().get();
+        Assert.assertEquals("application/hal+" + subPath,
+                            response.getMetadata().getFirst("Content-Type"));
+    }
+
+    private ContentRepresentation readRepresentation() {
+        return target("/test/" + subPath).request().get(ContentRepresentation.class);
+    }
+
+    private ReadableRepresentation readEmbeddedRepresentation() {
+        return readRepresentation().getResourcesByRel(EXTRA_REL).get(0);
+    }
+}


### PR DESCRIPTION
I took the StandardRepresentationFactory route and added a few tests for good measure.  This means halbuilder-jaxrs now depends on quite a lot of stuff.

In a separate PR I'd modify the existing writer support class to re-use HalBuilderMediaTypes logic, little as it is.
