### PR TITLE
make MessageBudyWriter explicitly use UTF-8

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder/jaxrs/HalBuilderMediaTypes.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/jaxrs/HalBuilderMediaTypes.java
@@ -10,6 +10,7 @@ import com.theoryinpractise.halbuilder.api.RepresentationFactory;
 class HalBuilderMediaTypes {
     private static final MediaType HAL_JSON_TYPE = MediaType.valueOf(RepresentationFactory.HAL_JSON);
     private static final MediaType HAL_XML_TYPE = MediaType.valueOf(RepresentationFactory.HAL_XML);
+    static final String DEFAULT_ENCODING = "UFT-8";
 
     /**
      * Is the given media type supported by HalBuilder?

--- a/src/main/java/com/theoryinpractise/halbuilder/jaxrs/JaxRsHalBuilderReaderSupport.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/jaxrs/JaxRsHalBuilderReaderSupport.java
@@ -28,7 +28,8 @@ public class JaxRsHalBuilderReaderSupport implements MessageBodyReader<ContentRe
 
     @Override
     public ContentRepresentation readFrom(Class aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap multivaluedMap, InputStream inputStream) throws IOException {
-	return factory.readRepresentation(mediaType.toString(), new InputStreamReader(inputStream, "UTF-8"));
+	return factory.readRepresentation(mediaType.toString(),
+                                          new InputStreamReader(inputStream, HalBuilderMediaTypes.DEFAULT_ENCODING));
     }
 
 }

--- a/src/main/java/com/theoryinpractise/halbuilder/jaxrs/JaxRsHalBuilderSupport.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/jaxrs/JaxRsHalBuilderSupport.java
@@ -33,7 +33,8 @@ public class JaxRsHalBuilderSupport implements MessageBodyWriter {
     @Override
     public void writeTo(Object o, Class aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap multivaluedMap, OutputStream outputStream) throws IOException, WebApplicationException {
         ReadableRepresentation representation = (ReadableRepresentation) o;
-        representation.toString(mediaType.toString(), new OutputStreamWriter(outputStream));
+        representation.toString(mediaType.toString(),
+                                new OutputStreamWriter(outputStream, HalBuilderMediaTypes.DEFAULT_ENCODING));
     }
 
 }


### PR DESCRIPTION
As Mark suggested on the mailing list.

This is in-line with the handling inside of Jackson MessageBodyWriter: https://github.com/FasterXML/jackson-jaxrs-providers/blob/master/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java#L665
