### PR TITLE
MessageBodyWriter#getSize is supposed to return -1 now

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder/jaxrs/JaxRsHalBuilderSupport.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/jaxrs/JaxRsHalBuilderSupport.java
@@ -26,8 +26,7 @@ public class JaxRsHalBuilderSupport implements MessageBodyWriter {
 
     @Override
     public long getSize(Object o, Class aClass, Type type, Annotation[] annotations, MediaType mediaType) {
-        ReadableRepresentation representation = (ReadableRepresentation) o;
-        return representation.toString(mediaType.toString()).length();
+        return -1;
     }
 
     @Override


### PR DESCRIPTION
see
https://jax-rs-spec.java.net/nonav/2.0/apidocs/javax/ws/rs/ext/MessageBodyWriter.html#getSize%28T,%20java.lang.Class,%20java.lang.reflect.Type,%20java.lang.annotation.Annotation[],%20javax.ws.rs.core.MediaType%29

> As of JAX-RS 2.0, the method has been deprecated and the value returned by the method is ignored by a JAX-RS runtime. All MessageBodyWriter implementations are advised to return -1 from the method.

fixes #6
